### PR TITLE
Add my MacBooks

### DIFF
--- a/site/blog/monitors-mac/index.md
+++ b/site/blog/monitors-mac/index.md
@@ -81,6 +81,10 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="doesnt_work.png" height=64> <span>Samsung G70A 28" 4K 144 Hz</span></div>
 
+## <img src="mbp_16_2020.png" height=32> <span>MacBook Pro (16-inch, 2019) w/ Radeon Pro 5300M</span>
+
+<div class="row"><img src="works.png" height=64> <span>Gigabyte M32UC with <a href="https://www.amazon.com/dp/B08B3XNZGS?ref=ppx_yo2ov_dt_b_product_details&th=1">JCE-DP/USB C-2m cable</a> at only 120Hz and with graphics switching disabled</span></div>
+
 ## <img src="mbp_16_2020.png" height=32> <span>MacBook Pro (16-inch, 2019) w/ Radeon Pro 5500M</span>
 
 <div class="row"><img src="works.png" height=64> <span>Acer Nitro XV3 (XV273K Pbmiipphzx)</span></div>
@@ -216,6 +220,10 @@ Gigabyte M32U (4k @ 144Hz)</span></div>
 
 <div class="row"><img src="works.png" height=64> <span>
 Gigabyte M32U (4k @ 144Hz)</span></div>
+
+## <img src="mbp_16_2020.png" height=32> <span>MacBook Pro (M2 Pro, 16-inch, 2023)</span>
+
+<div class="row"><img src="works.png" height=64> <span>Gigabyte M32UC with <a href="https://www.amazon.com/dp/B08B3XNZGS?ref=ppx_yo2ov_dt_b_product_details&th=1">JCE-DP/USB C-2m cable</a> at 144Hz and variable 48-144Hz</span></div>
 
 # How to contribute?
 


### PR DESCRIPTION
Thanks for the list, it was very helpful to me since there is basically no info on the internet and you'll just see 60Hz everywhere. There are some quirks to mention (I use BetterDisplay for some extra toggles).

2019 MacBook - sometimes it shows static and resets the display until I reconnecting the DisplayPort in the monitor and plug it back in, I suspect there is something the monitor remembers between devices that breaks something as it is specifically triggered by swapping laptops. Shows up with HDR in BetterDisplay but not in OS Displays.
2023 MacBook - Shows up with no HDR or bits per sample on BetterDisplay (where these options are in the other one, but frankly I trust this one more as it works far more reliably).

I will also note that when you plug this monitor into either MacBook at 60Hz the colors look _absolutely terrifyingly bad_, so much so that if you can't run this thing at 144Hz it is a significantly worse experience than any other given 60Hz display I've used.

Further than this I would like to know if you know what docks everyone is using, I am specifically using a direct cable right now because its not clear to me which dock will actually allow for 120Hz and keyboard/mice/pd for the one cable dream.

<img width="1307" alt="Screenshot 2023-10-28 at 11 26 20" src="https://github.com/tonsky/tonsky.me/assets/10627822/aa646902-efa0-496d-a143-1bc06580680c">
<img width="392" alt="Screenshot 2023-10-28 at 11 22 26" src="https://github.com/tonsky/tonsky.me/assets/10627822/c628a351-6749-4d3a-ae53-41ff4d516b30">

<img width="348" alt="Screenshot 2023-10-28 at 11 15 34" src="https://github.com/tonsky/tonsky.me/assets/10627822/280cf0e3-4861-4f15-b87a-783eadfbaf58">
<img width="1017" alt="Screenshot 2023-10-28 at 11 15 43" src="https://github.com/tonsky/tonsky.me/assets/10627822/52d3c401-3c6f-44b7-865b-0b3db9f42ea4">

