### PR TITLE
Confirm that the Gigabyte M32U works at 144Hz with M2 Max 2023 Studio

### DIFF
--- a/site/blog/monitors-mac/index.md
+++ b/site/blog/monitors-mac/index.md
@@ -225,6 +225,12 @@ Gigabyte M32U (4k @ 144Hz)</span></div>
 
 <div class="row"><img src="works.png" height=64> <span>Gigabyte M32UC with <a href="https://www.amazon.com/dp/B08B3XNZGS?ref=ppx_yo2ov_dt_b_product_details&th=1">JCE-DP/USB C-2m cable</a> at 144Hz and variable 48-144Hz</span></div>
 
+
+## <img src="studio_2022.png" height=32> <span>Mac Studio (M2 Mac, 2023)</span>
+
+<div class="row"><img src="works.png" height=64> <span>Gigabyte M32U (4k @ 144Hz)</span></div>
+
+
 # How to contribute?
 
 If you have a combination of 4k monitor with 120+ Hz refresh rate and a Mac that’s not listed here, please [open a PR](https://github.com/tonsky/tonsky.me/blob/main/site/blog/monitors-mac/index.md) (don’t worry about graphics/icons, I can add those myself).


### PR DESCRIPTION

Confirm that the Gigabyte M32U works at 144Hz with the Apple M2 Max 2023 Studio Mac

See attached supporting image here for "proof":

![GigabyteM32U_at_144Hz_with_Studio_Mac_M2_Max](https://github.com/tonsky/tonsky.me/assets/882973/30d02cb9-594e-4150-b894-b618cde029b7)


