### PR TITLE
MBP 2020 M1 works with Dell G3223Q

### DIFF
--- a/site/blog/monitors-mac/index.md
+++ b/site/blog/monitors-mac/index.md
@@ -153,6 +153,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GP950-B (4k @ 144Hz)</span></div>
 
+<div class="row"><img src="works.png" height=64> <span>Dell G3223Q (4k @ 144Hz)</span></div>
+
 ## <img src="mbp_14_2021.png" height=32> <span>MacBook Pro (M1 Pro, 14-inch, 2021)</span>
 
 <div class="row"><img src="works.png" height=64> <span>Acer Nitro XV3 (XV273K Pbmiipphzx)</span></div>


### PR DESCRIPTION
connected with a USB C to DsiplayPort 1.4 cable (brand Moxanor)

![image](https://github.com/user-attachments/assets/5c14ee66-76aa-47dd-a685-9c5921dcd54e)

![image](https://github.com/user-attachments/assets/dc91bdef-40d4-497c-9423-1d90a382d52e)



