### PR TITLE
Add mbp 2018 15in not working with Gigabyte M32UC and MBP 2018 order

### DIFF
--- a/site/blog/monitors-mac/index.md
+++ b/site/blog/monitors-mac/index.md
@@ -48,6 +48,15 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="doesnt_work.png" height=64> <span>LG TV 65NANO867NA</span></div>
 
+## <img src="mbp_15_2019.png" height=32> <span>MacBook Pro (15-inch, 2018) w/ Radeon Pro 555X</span>
+
+<div class="row"><img src="doesnt_work.png" height=64> <span>Gigabyte M32UC (does not work with <a href="https://a.co/d/7MLoRkb">Maxonar USB C to DisplayPort</a> cable nor with graphics switching disabled)</span></div>
+
+## <img src="mbp_15_2019.png" height=32> <span>MacBook Pro (15-inch, 2018) w/ Radeon Pro 560X</span>
+
+<div class="row"><img src="doesnt_work.png" height=64> <span>Gigabyte M28U</span></div>
+<div class="row"><img src="works.png" height=64> <span>Gigabyte M32U (4k @ 120Hz)</span></div>
+
 ## <img src="mbp_13_2019.png" height=32> <span>MacBook Pro (13-inch, 2019)</span>
 
 <div class="row"><img src="doesnt_work.png" height=64> <span>Acer Nitro XV3 (XV273K Pbmiipphzx)</span></div>
@@ -65,11 +74,6 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 ## <img src="mp_2019.png" height=32> <span>Mac Pro (2019) w/ Radeon Pro 580X</span>
 
 <div class="row"><img src="works.png" height=64> <span>Acer Predator X27</span></div>
-
-## <img src="mbp_15_2019.png" height=32> <span>MacBook Pro (15-inch, 2018) w/ Radeon Pro 560X</span>
-
-<div class="row"><img src="doesnt_work.png" height=64> <span>Gigabyte M28U</span></div>
-<div class="row"><img src="works.png" height=64> <span>Gigabyte M32U (4k @ 120Hz)</span></div>
 
 ## <img src="mbp_16_2020.png" height=32> <span>MacBook Pro (16-inch, 2019) w/ Radeon Pro 5300M</span>
 


### PR DESCRIPTION
- Add MBP 2018 15" not working with Gigabyte M32UC using USB C to Displayport 1.4 cable
- Fix order on MBP 2018 on the page to be sequential by year (was previously out of order)

On SwitchResX, there is no option above 720p to run over 60Hz **with HiDPI** which is a bummer.
<img width="1121" alt="Screenshot 2024-12-08 at 4 11 46 PM" src="https://github.com/user-attachments/assets/9b8bb47b-5521-4551-9bbd-f4959f44379a">



<img width="392" alt="Screenshot 2024-12-08 at 9 23 04 PM" src="https://github.com/user-attachments/assets/9ec1f702-db58-4d27-b44b-15fbcf1eea04">

![Screenshot 2024-12-08 at 9 00 31 PM](https://github.com/user-attachments/assets/71f18b15-04d1-44b6-993f-66cd291ae7f4)
